### PR TITLE
Feat/update deploy script

### DIFF
--- a/.env_devnet
+++ b/.env_devnet
@@ -1,0 +1,1 @@
+0x6d1fa9062223bccdb8db99ff53b8d820

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Develop Cairo with:
 source ~/cairo_venv/bin/activate
 ```
 
+Build the demo contracts by running
+
+```
+protostar build
+```
+
+See (this guide)[https://docs.swmansion.com/protostar/docs/tutorials/installation] for how to install protostar.
+
+
 Deploy demo contracts by updating the `protostar.toml` profile that you want to deploy to {testnet, testnet2, devnet}. You will need to locally define the `account-address` field to the address you want to deploy from and the `private-key-path` to the file where you will write the private key of the account address you choose.
 
 Then run

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Develop Cairo with:
 source ~/cairo_venv/bin/activate
 ```
 
+Deploy demo contracts by updating the `protostar.toml` profile that you want to deploy to {testnet, testnet2, devnet}. You will need to locally define the `account-address` field to the address you want to deploy from and the `private-key-path` to the file where you will write the private key of the account address you choose.
+
+Then run
+```
+./scripts/deploy.sh <profile>
+```
+
+It will default to the profile `devnet` if none is passed into the script.
+
 ## Apibara + Devnet
 
 ```

--- a/protostar.toml
+++ b/protostar.toml
@@ -11,8 +11,8 @@ move_system = ["contracts/systems/Move.cairo"]
 [profile.devnet.project]
 gateway-url = "http://127.0.0.1:5050/"
 chain-id = 1536727068981429685321
-private-key-path = "./.env"
-account-address=""  
+private-key-path = "./.env_devnet"
+account-address="0x605d49242d6d1476d93f2282900e05ec3120f796b03f238bd8a339005363d49"  
 
 [profile.testnet.project]
 network="testnet"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,13 +3,32 @@
 # causes bash to exit immediately if any command returns a non-zero exit status or if it tries to use an unset variable
 set -eu
 
+# Print usage information if the -h flag is passed
+while getopts ":h" opt; do
+  case ${opt} in
+    h )
+      echo "Usage: ./deploy.sh [-h] [profile]"
+      echo ""
+      echo "Options:"
+      echo "  -h           Show this help message"
+      echo ""
+      echo "Arguments:"
+      echo "  profile      The protostar profile to use (default: devnet)"
+      exit 0
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
 # Determine the absolute path of the entry point script
 entry_point_path=$(dirname "$(readlink -f "$0")")
 
-profile=${1:-"testnet"}
-contract_name=${2:-"world"}
+profile=${1:-"devnet"}
 
-class_hash_file=./build/class_hashes.json
 build_dir=./build
 deployment_cache_file=./deploys.json
 
@@ -17,23 +36,26 @@ deployment_cache_file=./deploys.json
 
 ensure_deployment_cache $deployment_cache_file
 
-if [ "$contract_name" != "world" ]; then
-	# we need to pass deployment the operative world contract
-	deployed_world_address=$(jq -r ".$profile.world" $deployment_cache_file)
-	if [ "$deployed_world_address" = "null" ]; then
-		# If the variable is empty, print an error message and exit the script
-		echo "Must have world contract for given profile ($profile) to deploy $contract_name):"
-		echo "Run ./scripts/deploy $profile world, then try again."
-		exit 1
+contract_list=("world" "location_component" "move_system")
 
-	fi
+for contract_name in "${contract_list[@]}"; do
+    if [ "$contract_name" != "world" ]; then
+	      # we need to pass deployment the operative world contract
+	      deployed_world_address=$(jq -r ".$profile.world" $deployment_cache_file)
+	      if [ "$deployed_world_address" = "null" ]; then
+		        # If the variable is empty, print an error message and exit the script
+		        echo "Must have world contract for given profile ($profile) to deploy $contract_name):"
+		        exit 1
+            
+	      fi
+        
+	      deploy_protostar $contract_name $deployed_world_address
+	      update_json_value $profile $contract_name $deployed_address $deployment_cache_file
 
-	deploy_protostar $contract_name $deployed_world_address
-	update_json_value $profile $contract_name $deployed_address $deployment_cache_file
+    else
+	      # In the case of world, we have no init values to pass to the constructor
+	      deploy_protostar $contract_name ""
+	      update_json_value $profile $contract_name $deployed_address $deployment_cache_file
+    fi
+done
 
-else
-	# In the case of world, we have no init values to pass to the constructor
-	deploy_protostar $contract_name ""
-	update_json_value $profile $contract_name $deployed_address $deployment_cache_file
-
-fi


### PR DESCRIPTION
Output looks like so (assuming the protostar account-address and private-key-path is set correctly with a funded account:

```shell
[jmsb:~/exps/onchain-games/dojo-core]$ ./scripts/deploy.sh testnet
./scripts/deploy.sh testnet
protostar -p testnet declare "./build/world.json" --max-fee auto --json
16:10:29 [INFO] Execution time: 15.11 s
protostar -p testnet deploy 0x019f87717e9ece6b766a12ae621d671dcdd26e8bc2cf77ac18d19b1e5c0dfa9d --inputs --max-fee auto --json
16:10:39 [INFO] Execution time: 8.67 s
world deployed to testnet at 0x06b92a7d5e4191779da6751e3afc7844f47799f0fa6072c8a29a20a76132e4ab
protostar -p testnet declare "./build/location_component.json" --max-fee auto --json
16:10:51 [INFO] Execution time: 11.86 s
protostar -p testnet deploy 0x0172c018a61a503a9a09096f4cd153ce24abb0072741cf97bc9d7149166ddf77 --inputs 0x06b92a7d5e4191779da6751e3afc7844f47799f0fa6072c8a29a20a76132e4ab --max-fee auto --json
16:10:59 [INFO] Execution time: 6.95 s
location_component deployed to testnet at 0x04968a7d49d50d3216ab761dfc9087f9d978aa1f3b71e0d737dcc6558abed361
protostar -p testnet declare "./build/move_system.json" --max-fee auto --json
16:11:12 [INFO] Execution time: 12.66 s
protostar -p testnet deploy 0x0633bed89b8f7b33aeac2307eb6847acb5deca97fff1c39a6a13a7811462cafc --inputs 0x06b92a7d5e4191779da6751e3afc7844f47799f0fa6072c8a29a20a76132e4ab --max-fee auto --json
16:11:20 [INFO] Execution time: 6.88 s
move_system deployed to testnet at 0x0545847bf11646775c402f0756a78b3a10a5b29799733a1bcf71869d8f765450
```